### PR TITLE
Reposition option bar and refactor into LessonPrimaryLayout

### DIFF
--- a/components/LessonOptionsBar.tsx
+++ b/components/LessonOptionsBar.tsx
@@ -69,7 +69,7 @@ const styles = StyleSheet.create({
   optionsBar: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    height: 40,
+    marginTop: 40,
   },
   closeIcon: {
     marginLeft: 24,

--- a/components/LessonPrimaryLayout.tsx
+++ b/components/LessonPrimaryLayout.tsx
@@ -10,6 +10,7 @@ import {
 import type {RootStackParamList} from '../types';
 import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {Dimensions} from 'react-native';
+import LessonOptionsBar from './LessonOptionsBar';
 
 const leftArrow = require('assets/images/left-arrow-3x.png');
 const rightArrow = require('assets/images/right-arrow-3x.png');
@@ -79,6 +80,16 @@ export default function LessonPrimaryLayout({
           )}
         </View>
       </View>
+      <View style={styles.optionBarWrapper}>
+        <LessonOptionsBar
+          navigation={navigation}
+          elementId={elementId}
+          displayQuestionAnswerScreen={false}
+          closeCallback={() =>
+            navigation.navigate('FindScanEucalyptusTreeScreen')
+          }
+        />
+      </View>
     </View>
   );
 }
@@ -89,6 +100,12 @@ const styles = StyleSheet.create({
     display: 'flex',
     flexDirection: 'column',
     minHeight: '100%',
+    position: 'relative',
+  },
+  optionBarWrapper: {
+    position: 'absolute',
+    top: 0,
+    width: '100%',
   },
   body: {
     display: 'flex',

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -94,14 +94,15 @@ function RootNavigator() {
         name="LessonContentScreen"
         component={LessonContentScreen}
         options={{
-          headerShown: true,
-          headerBackVisible: true,
-          title: 'Stanford Nature',
+          headerShown: false,
         }}
       />
       <Stack.Screen
         name="QuestionAnswerScreen"
         component={QuestionAnswerScreen}
+        options={{
+          headerShown: false,
+        }}
       />
       <Stack.Screen
         name="NotFound"

--- a/screens/LessonContentScreen.tsx
+++ b/screens/LessonContentScreen.tsx
@@ -4,23 +4,17 @@ import type {RootStackParamList} from '../types';
 import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {EucalyptusLesson} from '../lesson_content/EucalyptusLesson';
 import InformationalComponent from './lesson_elements/InformationalComponent';
-import LessonOptionsBar from '../components/LessonOptionsBar';
 
 export default function LessonContentScreen({
   navigation,
   route,
 }: NativeStackScreenProps<RootStackParamList, 'LessonContentScreen'>) {
-  function closeCallback() {
-    navigation.navigate('FindScanEucalyptusTreeScreen');
-  }
-
   const elementId = route.params?.elementId ?? 0;
   const totalElements = EucalyptusLesson.elements.length;
 
   const element = EucalyptusLesson.elements[elementId];
 
   let reactElement = null;
-  let optionsBar = null;
 
   if (element.__type === 'InformationalElement') {
     reactElement = (
@@ -33,35 +27,11 @@ export default function LessonContentScreen({
     );
   }
 
-  if (element.__type === 'InformationalElement') {
-    optionsBar = (
-      <View style={styles.optionsBarArea}>
-        <LessonOptionsBar
-          navigation={navigation}
-          elementId={elementId}
-          displayQuestionAnswerScreen={false}
-          closeCallback={closeCallback}
-        />
-      </View>
-    );
-  }
-
-  return (
-    <View style={styles.mainContainer}>
-      {reactElement}
-      {optionsBar}
-    </View>
-  );
+  return <View style={styles.mainContainer}>{reactElement}</View>;
 }
 
 const styles = StyleSheet.create({
   mainContainer: {
     flex: 1,
-  },
-  optionsBarArea: {
-    position: 'absolute',
-    top: 0,
-    width: '100%',
-    height: 70,
   },
 });

--- a/screens/Playground.tsx
+++ b/screens/Playground.tsx
@@ -101,6 +101,7 @@ export default function Playground({
         placeHolderText={'Add notes'}
         isSaveEnabled={true}
         onSubmit={() => {}}
+        targetImage={null}
       />
     </KeyboardAvoidingView>
   );

--- a/screens/QuestionAnswerScreen.tsx
+++ b/screens/QuestionAnswerScreen.tsx
@@ -82,7 +82,7 @@ export default function QuestionAnswerScreen(props: Props) {
       style={styles.container}
       behavior={Platform.OS == 'ios' ? 'padding' : 'height'}
     >
-      <View style={{width: '100%', height: '70%', marginTop: 45}}>
+      <View style={{width: '100%', height: '70%', marginTop: 104}}>
         <ScrollView style={styles.scrollView}>{data}</ScrollView>
       </View>
       <View style={{flex: 1, marginTop: 20}}>


### PR DESCRIPTION
<img width="524" alt="Screen Shot 2022-05-05 at 12 59 20 PM" src="https://user-images.githubusercontent.com/3389743/167015856-505d2299-1815-4f00-9791-f2bf01c38704.png">

This also moves the option bar into the LessonPrimaryLayout component instead of the content screen itself