### PR TITLE
Refactor lesson layout to support more styles, and add chat scrollview

### DIFF
--- a/components/ChatScrollViewContainer.tsx
+++ b/components/ChatScrollViewContainer.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import {useRef, useState} from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  View,
+  StyleSheet,
+  Text,
+} from 'react-native';
+import TextVoiceInput from '../components/TextVoiceInput';
+import ChatBubble from '../components/ChatBubble';
+import findAnswer from '../components/questionAnswerModelInference';
+import LessonOptionsBar from '../components/LessonOptionsBar';
+import {RootStackParamList} from '../types';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {ChatBubbleObject} from '../types';
+
+type Props = {
+  chatElements: Array<JSX.Element>;
+};
+
+export default function ChatScrollViewContainer({
+  chatElements,
+}: Props): JSX.Element {
+  const scrollViewRef = useRef<ScrollView>(null);
+  return (
+    <ScrollView
+      style={styles.scrollView}
+      ref={scrollViewRef}
+      onContentSizeChange={() =>
+        scrollViewRef?.current?.scrollToEnd({animated: true})
+      }
+    >
+      <View style={styles.scrollContents}>
+        {chatElements.map((element, index) => (
+          <View style={styles.bubbleWrapperBottomMargin} key={index}>
+            {element}
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollView: {},
+  scrollContents: {
+    marginTop: 16,
+    marginHorizontal: 24,
+  },
+  bubbleWrapperBottomMargin: {
+    marginBottom: 16,
+  },
+});

--- a/components/FeaturedCoverImage.tsx
+++ b/components/FeaturedCoverImage.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import {ImageBackground, View, ImageSourcePropType} from 'react-native';
+import {Dimensions} from 'react-native';
+
+type Props = {
+  imageSource: ImageSourcePropType | null;
+};
+
+export default function FeaturedCoverImage({imageSource}: Props) {
+  const windowWidth = Dimensions.get('window').width;
+
+  return (
+    <View
+      style={{
+        height: windowWidth,
+      }}
+    >
+      {imageSource != null && (
+        <ImageBackground
+          source={imageSource}
+          resizeMode="cover"
+          style={{
+            height: windowWidth,
+          }}
+        />
+      )}
+    </View>
+  );
+}

--- a/components/LessonPrimaryLayout.tsx
+++ b/components/LessonPrimaryLayout.tsx
@@ -96,8 +96,9 @@ const styles = StyleSheet.create({
   mainContainer: {
     display: 'flex',
     flexDirection: 'column',
-    minHeight: '100%',
+    maxHeight: '100%',
     position: 'relative',
+    backgroundColor: '#121212',
   },
   optionBarWrapper: {
     position: 'absolute',
@@ -105,17 +106,21 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   body: {
-    display: 'flex',
+    // display: 'flex',
     flexGrow: 1,
-    margin: 12,
+    flexShrink: 1,
+    flexBasis: 'auto',
+    height: '100%',
   },
   imageSection: {
-    display: 'flex',
-    flexBasis: 'auto',
+    // display: 'flex',
+    // flexBasis: 'auto',
     flexGrow: 0,
+    flexShrink: 0,
   },
   navigationSection: {
     flexGrow: 0,
+    flexShrink: 0,
     marginBottom: 90,
     display: 'flex',
     flexDirection: 'row',

--- a/components/LessonPrimaryLayout.tsx
+++ b/components/LessonPrimaryLayout.tsx
@@ -9,7 +9,6 @@ import {
 } from 'react-native';
 import type {RootStackParamList} from '../types';
 import type {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {Dimensions} from 'react-native';
 import LessonOptionsBar from './LessonOptionsBar';
 
 const leftArrow = require('assets/images/left-arrow-3x.png');
@@ -18,7 +17,7 @@ const rightArrow = require('assets/images/right-arrow-3x.png');
 type Props = {
   elementId: number;
   totalElements: number;
-  imageSource: number | null;
+  topElement: React.ReactNode;
   children: React.ReactNode;
 };
 
@@ -26,24 +25,12 @@ export default function LessonPrimaryLayout({
   navigation,
   elementId,
   totalElements,
-  imageSource,
+  topElement,
   children,
 }: NativeStackScreenProps<RootStackParamList, 'LessonContentScreen'> & Props) {
-  const windowHeight = Dimensions.get('window').height;
-
   return (
     <View style={styles.mainContainer}>
-      {imageSource != null && (
-        <View style={styles.imageSection}>
-          <ImageBackground
-            source={imageSource}
-            resizeMode="cover"
-            style={{
-              height: windowHeight * 0.4,
-            }}
-          />
-        </View>
-      )}
+      <View style={styles.topSection}>{topElement}</View>
       <View style={styles.body}>{children}</View>
       <View style={styles.navigationSection}>
         <View style={styles.arrowContainer}>
@@ -112,7 +99,7 @@ const styles = StyleSheet.create({
     flexBasis: 'auto',
     height: '100%',
   },
-  imageSection: {
+  topSection: {
     // display: 'flex',
     // flexBasis: 'auto',
     flexGrow: 0,

--- a/lesson_content/EucalyptusLesson.ts
+++ b/lesson_content/EucalyptusLesson.ts
@@ -29,5 +29,13 @@ export const EucalyptusLesson: Lesson = {
       ],
       imageFilenames: [require('assets/images/usmap-placeholder.jpg')],
     },
+    {
+      __type: 'ImageCaptureElement',
+      messages: [
+        'What else makes eucalyptus trees unique? First, let’s take a closer look at their leaves. Take three close-up photos of their leaves for your records.',
+      ],
+      imageFilenames: [require('assets/images/GettyImages-480806545.jpeg')],
+      imagesCapturesRequired: 1,
+    },
   ],
 };

--- a/lesson_content/lessonTypes.ts
+++ b/lesson_content/lessonTypes.ts
@@ -65,7 +65,7 @@ export interface ObjectFinderElement extends GenericElement {
 export interface ImageCaptureElement extends GenericElementWithImages {
   __type: 'ImageCaptureElement';
   messages: Messages;
-  imagesRequired: number;
+  imagesCapturesRequired: number;
 }
 
 /**

--- a/screens/FindScanEucalyptusTreeScreen.tsx
+++ b/screens/FindScanEucalyptusTreeScreen.tsx
@@ -110,6 +110,7 @@ export default function FindScanEucalyptusTreeScreen({
         <View style={styles.messageHolder}>
           {messageElements.map((element, index) => (
             <View
+              key={index}
               style={
                 index !== messageElements.length - 1
                   ? styles.messageParagraphBottomSpacing

--- a/screens/LessonContentScreen.tsx
+++ b/screens/LessonContentScreen.tsx
@@ -4,6 +4,7 @@ import type {RootStackParamList} from '../types';
 import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {EucalyptusLesson} from '../lesson_content/EucalyptusLesson';
 import InformationalComponent from './lesson_elements/InformationalComponent';
+import ImageCaptureLessonScreen from './lesson_elements/ImageCaptureLessonScreen';
 
 export default function LessonContentScreen({
   navigation,
@@ -19,6 +20,16 @@ export default function LessonContentScreen({
   if (element.__type === 'InformationalElement') {
     reactElement = (
       <InformationalComponent
+        {...{navigation, route}}
+        elementProps={element}
+        elementId={elementId}
+        totalElements={totalElements}
+      />
+    );
+  }
+  if (element.__type === 'ImageCaptureElement') {
+    reactElement = (
+      <ImageCaptureLessonScreen
         {...{navigation, route}}
         elementProps={element}
         elementId={elementId}

--- a/screens/lesson_elements/ImageCaptureLessonScreen.tsx
+++ b/screens/lesson_elements/ImageCaptureLessonScreen.tsx
@@ -5,6 +5,8 @@ import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import type {ImageCaptureElement} from '../../lesson_content/lessonTypes';
 import ChatBubble from '../../components/ChatBubble';
 import LessonPrimaryLayout from '../../components/LessonPrimaryLayout';
+import ChatScrollViewContainer from '../../components/ChatScrollViewContainer';
+import FeaturedCoverImage from '../../components/FeaturedCoverImage';
 
 type Props = {
   elementProps: ImageCaptureElement;
@@ -21,25 +23,27 @@ export default function ImageCaptureLessonScreen({
 }: NativeStackScreenProps<RootStackParamList, 'LessonContentScreen'> & Props) {
   const {imageFilenames, imagesCapturesRequired, messages} = elementProps;
 
-  const imageSource = imageFilenames?.[0];
+  const imageSource = imageFilenames?.[0] ?? null;
 
   return (
     <LessonPrimaryLayout
       elementId={elementId}
       totalElements={totalElements}
-      imageSource={imageSource ?? null}
+      topElement={<FeaturedCoverImage imageSource={imageSource} />}
       navigation={navigation}
       route={route}
     >
-      {messages.map((message, i) => (
-        <ChatBubble
-          key={i}
-          alignment="left"
-          view={<Text style={styles.bubbleText}>{message}</Text>}
-          bubbleColor={'rgba(38, 38, 39, 1)'}
-          backgroundColor={'#121212'}
-        />
-      ))}
+      <ChatScrollViewContainer
+        chatElements={messages.map((message, i) => (
+          <ChatBubble
+            key={i}
+            alignment="left"
+            view={<Text style={styles.bubbleText}>{message}</Text>}
+            bubbleColor={'rgba(38, 38, 39, 1)'}
+            backgroundColor={'#121212'}
+          />
+        ))}
+      />
     </LessonPrimaryLayout>
   );
 }

--- a/screens/lesson_elements/ImageCaptureLessonScreen.tsx
+++ b/screens/lesson_elements/ImageCaptureLessonScreen.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import {Text, StyleSheet} from 'react-native';
+import type {RootStackParamList} from '../../types';
+import type {NativeStackScreenProps} from '@react-navigation/native-stack';
+import type {ImageCaptureElement} from '../../lesson_content/lessonTypes';
+import ChatBubble from '../../components/ChatBubble';
+import LessonPrimaryLayout from '../../components/LessonPrimaryLayout';
+
+type Props = {
+  elementProps: ImageCaptureElement;
+  elementId: number;
+  totalElements: number;
+};
+
+export default function ImageCaptureLessonScreen({
+  navigation,
+  route,
+  elementProps,
+  elementId,
+  totalElements,
+}: NativeStackScreenProps<RootStackParamList, 'LessonContentScreen'> & Props) {
+  const {imageFilenames, imagesCapturesRequired, messages} = elementProps;
+
+  const imageSource = imageFilenames?.[0];
+
+  return (
+    <LessonPrimaryLayout
+      elementId={elementId}
+      totalElements={totalElements}
+      imageSource={imageSource ?? null}
+      navigation={navigation}
+      route={route}
+    >
+      {messages.map((message, i) => (
+        <ChatBubble
+          key={i}
+          alignment="left"
+          view={<Text style={styles.bubbleText}>{message}</Text>}
+          bubbleColor={'rgba(38, 38, 39, 1)'}
+          backgroundColor={'#121212'}
+        />
+      ))}
+    </LessonPrimaryLayout>
+  );
+}
+
+// TODO: Use colors from the theme instead of hardcoding
+const styles = StyleSheet.create({
+  mainContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: '100%',
+  },
+  messageSection: {
+    display: 'flex',
+    flexGrow: 1,
+    margin: 12,
+  },
+  imageSection: {
+    display: 'flex',
+    flexBasis: 'auto',
+    flexGrow: 0,
+  },
+  navigationSection: {
+    flexGrow: 0,
+    marginBottom: 90,
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  arrowContainer: {
+    // flexGrow: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 10 + 50,
+    height: 22 + 50,
+  },
+  arrowButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 10 + 50,
+    height: 22 + 50,
+  },
+  arrow: {
+    width: 10,
+    height: 22,
+  },
+  lessonNumber: {
+    textAlign: 'center',
+    fontSize: 11,
+    fontWeight: '500',
+    // TODO: is this font natively supported on both platforms?
+    fontFamily: 'SF Pro Text',
+    color: 'white',
+  },
+  lessonNumberContainer: {flexGrow: 1, textAlign: 'center'},
+  bubbleText: {
+    fontSize: 16,
+    color: 'rgba(255, 255, 255, 1)',
+  },
+});

--- a/screens/lesson_elements/InformationalComponent.tsx
+++ b/screens/lesson_elements/InformationalComponent.tsx
@@ -5,6 +5,7 @@ import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import type {InformationalElement} from '../../lesson_content/lessonTypes';
 import ChatBubble from '../../components/ChatBubble';
 import LessonPrimaryLayout from '../../components/LessonPrimaryLayout';
+import ChatScrollViewContainer from '../../components/ChatScrollViewContainer';
 
 type Props = {
   elementProps: InformationalElement;
@@ -31,15 +32,17 @@ export default function InformationalComponent({
       navigation={navigation}
       route={route}
     >
-      {messages.map((message, i) => (
-        <ChatBubble
-          key={i}
-          alignment="left"
-          view={<Text style={styles.bubbleText}>{message}</Text>}
-          bubbleColor={'rgba(38, 38, 39, 1)'}
-          backgroundColor={'#121212'}
-        />
-      ))}
+      <ChatScrollViewContainer
+        chatElements={messages.map((message, i) => (
+          <ChatBubble
+            key={i}
+            alignment="left"
+            view={<Text style={styles.bubbleText}>{message}</Text>}
+            bubbleColor={'rgba(38, 38, 39, 1)'}
+            backgroundColor={'#121212'}
+          />
+        ))}
+      />
     </LessonPrimaryLayout>
   );
 }

--- a/screens/lesson_elements/InformationalComponent.tsx
+++ b/screens/lesson_elements/InformationalComponent.tsx
@@ -6,6 +6,7 @@ import type {InformationalElement} from '../../lesson_content/lessonTypes';
 import ChatBubble from '../../components/ChatBubble';
 import LessonPrimaryLayout from '../../components/LessonPrimaryLayout';
 import ChatScrollViewContainer from '../../components/ChatScrollViewContainer';
+import FeaturedCoverImage from '../../components/FeaturedCoverImage';
 
 type Props = {
   elementProps: InformationalElement;
@@ -22,13 +23,13 @@ export default function InformationalComponent({
 }: NativeStackScreenProps<RootStackParamList, 'LessonContentScreen'> & Props) {
   const {imageFilenames, messages} = elementProps;
 
-  const imageSource = imageFilenames?.[0];
+  const imageSource = imageFilenames?.[0] ?? null;
 
   return (
     <LessonPrimaryLayout
       elementId={elementId}
       totalElements={totalElements}
-      imageSource={imageSource ?? null}
+      topElement={<FeaturedCoverImage imageSource={imageSource} />}
       navigation={navigation}
       route={route}
     >


### PR DESCRIPTION
This refactors the LessonPrimaryLayout to support different elements in the top and body, and it creates ChatScrollViewContainer to render chats with appropriate margins. 

It also adds a stub for the ImageCaptureLesson type