### PR TITLE
Fix unique key error on FindAndScanEucalytpusTreeScreen.

### DIFF
--- a/screens/FindScanEucalyptusTreeScreen.tsx
+++ b/screens/FindScanEucalyptusTreeScreen.tsx
@@ -110,6 +110,7 @@ export default function FindScanEucalyptusTreeScreen({
         <View style={styles.messageHolder}>
           {messageElements.map((element, index) => (
             <View
+              key={index}
               style={
                 index !== messageElements.length - 1
                   ? styles.messageParagraphBottomSpacing


### PR DESCRIPTION
This fixes the Unique key error problem when we load the FindAndScanEucalytpusTreeScreen in the app.

// Previous
<img width="1030" alt="Screen Shot 2022-05-11 at 12 52 12 PM" src="https://user-images.githubusercontent.com/27864363/167914660-3a4e35aa-5f78-4741-a86b-21e83845977c.png">

// Now
<img width="792" alt="Screen Shot 2022-05-11 at 12 52 23 PM" src="https://user-images.githubusercontent.com/27864363/167914663-136aae92-193a-47df-ad06-a4a975bef7eb.png">
