### PR TITLE
Fix Keyboard hidden problem on the QA Screen when typing a question.

### DIFF
--- a/screens/QuestionAnswerScreen.tsx
+++ b/screens/QuestionAnswerScreen.tsx
@@ -93,6 +93,7 @@ export default function QuestionAnswerScreen({
     <KeyboardAvoidingView
       style={styles.container}
       behavior={Platform.OS == 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={180}
     >
       <View style={{width: '100%', height: '70%', marginTop: 104}}>
         <ScrollView


### PR DESCRIPTION
This fixes the issue of text input getting hidden behind the keyboard view while typing a question. The behavior is different from expo snack vs local expo build. In the local build, the height of the text input is much higher as compared to the one we see on snack. Added the fix which looks good on the snack.