### PR TITLE
Check for speech module before using it

### DIFF
--- a/hooks/useTextToSpeech.ts
+++ b/hooks/useTextToSpeech.ts
@@ -1,6 +1,15 @@
-import {useEffect, useRef, useState, useCallback} from 'react';
+import {useEffect, useState, useCallback} from 'react';
 import React from 'react';
-import * as Speech from 'expo-speech';
+
+// Define a fallback no-op Speech object if the expo-speech module is not available.
+// @ts-ignore
+let Speech = {speak: (..._args) => {}, stop: (..._args) => {}};
+
+try {
+  Speech = require('expo-speech');
+} catch (e) {
+  console.error('expo-speech module not available. ');
+}
 
 /**
  *
@@ -10,10 +19,7 @@ import * as Speech from 'expo-speech';
 export default function useTextToSpeech(
   textToSpeak: Array<string>,
   initialShouldSpeak: boolean,
-) {
-  // const [speechQueue, setSpeechQueue] = useState<Array<string>>([]);
-  // const [currentlySpeakingIndex, setCurrentlySpeakingIndex] =
-  //   useState<number>(0);
+): {onStartSpeaking: () => void; onStopSpeaking: () => void} {
   const [lastCompletedIndex, setLastCompletedIndex] = useState<number>(-1);
 
   // @state shouldSpeak - whether or not the consumer of this hook wants us to be speaking
@@ -24,6 +30,7 @@ export default function useTextToSpeech(
 
   useEffect(() => {
     if (
+      Speech != null &&
       shouldSpeak &&
       !isSpeaking &&
       lastCompletedIndex < textToSpeak.length - 1
@@ -50,7 +57,10 @@ export default function useTextToSpeech(
   useEffect(() => {
     return () => {
       // Stop speaking on unmount
-      Speech.stop();
+      if (Speech != null) {
+        Speech.stop();
+      }
+
       setIsSpeaking(false);
     };
   }, []);
@@ -60,7 +70,9 @@ export default function useTextToSpeech(
   }, []);
 
   const onStopSpeaking = useCallback(() => {
-    Speech.stop();
+    if (Speech != null) {
+      Speech.stop();
+    }
     setIsSpeaking(false);
     setShouldSpeak(false);
   }, []);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "outdoor-learning",
       "version": "0.1.0",
       "dependencies": {
         "@expo/vector-icons": "^12.0.0",
@@ -2720,7 +2721,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -3330,9 +3330,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3664,9 +3661,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -6410,8 +6404,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -7292,7 +7285,6 @@
         "expo-application": "~4.0.2",
         "expo-asset": "~8.4.6",
         "expo-constants": "~13.0.2",
-        "expo-error-recovery": "~3.0.5",
         "expo-file-system": "~13.1.3",
         "expo-font": "~10.0.5",
         "expo-keep-awake": "~10.0.2",
@@ -9881,7 +9873,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -11447,7 +11438,6 @@
       "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -11489,9 +11479,6 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.9"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
       }
@@ -12483,9 +12470,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }


### PR DESCRIPTION
This PR makes it possible for the app to run even if the expo-speech module isn't available. In that case the calls to the speech API are no-ops.